### PR TITLE
Rename action branch to 'main'

### DIFF
--- a/.github/workflows/workflow-sync.yml
+++ b/.github/workflows/workflow-sync.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Fetching Local Repository
         uses: actions/checkout@master
       - name: Running Workflow Sync
-        uses: varunsridharan/action-github-workflow-sync@master
+        uses: varunsridharan/action-github-workflow-sync@main
         with:
           DRY_RUN: ${{ env.DRY_RUN }}
           REPOSITORIES: ${{ env.REPOSITORIES }}


### PR DESCRIPTION
The default branch of varunsridharan/action-github-workflow-sync was renamed to 'main'.